### PR TITLE
Adds methods for iterating and visiting 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+.envrc
+*.h5

--- a/API.md
+++ b/API.md
@@ -322,6 +322,32 @@ class(*), intent(out) :: attrval(:)  !< character, real, integer
 call h%delete_attr(dname, attr)
 ```
 
+## Iterate over all datasets in a group
+
+```fortran
+call h%iterate(group, callback)
+
+character(*), intent(in) :: group
+subroutine callback(group_name, object_name, object_type)
+  character(len=*), intent(in) :: group_name
+  character(len=*), intent(in) :: object_name
+  character(len=*), intent(in) :: object_type
+end subroutine
+```
+
+## Visit recursively all datasets starting from a group
+
+```fortran
+call h%visit(group, callback)
+
+character(*), intent(in) :: group
+subroutine callback(group_name, object_name, object_type)
+  character(len=*), intent(in) :: group_name
+  character(len=*), intent(in) :: object_name
+  character(len=*), intent(in) :: object_type
+end subroutine
+```
+
 ## high level operations
 
 These are single-call operations that are slower than the object-oriented methods above.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ endif()
 # --- h5fortran library
 
 add_library(h5fortran)
+
 target_include_directories(h5fortran PUBLIC
 $<BUILD_INTERFACE:${CMAKE_Fortran_MODULE_DIRECTORY}>
 $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>

--- a/fpm.toml
+++ b/fpm.toml
@@ -85,6 +85,3 @@ main = "test_iterate.f90"
 [[test]]
 name = "version"
 main = "test_version.f90"
-
-[dependencies]
-hdf5 = '*'

--- a/fpm.toml
+++ b/fpm.toml
@@ -75,6 +75,14 @@ name = "string"
 main = "test_string.f90"
 
 [[test]]
+name = "visit"
+main = "test_visit.f90"
+
+[[test]]
+name = "iterate"
+main = "test_iterate.f90"
+
+[[test]]
 name = "version"
 main = "test_version.f90"
 

--- a/fpm.toml
+++ b/fpm.toml
@@ -77,3 +77,6 @@ main = "test_string.f90"
 [[test]]
 name = "version"
 main = "test_version.f90"
+
+[dependencies]
+hdf5 = '*'

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,12 +1,16 @@
 set(s ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_sources(h5fortran PRIVATE
-${s}/utils.f90 ${s}/datatype.f90 ${s}/deflate.f90
+${s}/interface.f90
+${s}/utils.f90
+${s}/datatype.f90
+${s}/deflate.f90
 ${s}/read.f90 ${s}/read_scalar.f90 ${s}/read_ascii.f90 ${s}/reader.f90
 ${s}/write.f90 ${s}/write_scalar.f90 ${s}/writer.f90
 ${s}/reader_lt.f90 ${s}/writer_lt.f90
-${s}/interface.f90
 ${s}/attr.f90
 ${s}/attr_read.f90
 ${s}/attr_write.f90
+${s}/iterate.f90
+${s}/visit.f90
 )

--- a/src/interface.f90
+++ b/src/interface.f90
@@ -57,6 +57,8 @@ procedure, public :: softlink => create_softlink
 procedure, public :: is_open
 procedure, public :: delete_attr => attr_delete
 procedure, public :: exist_attr => attr_exist
+procedure, public :: iterate => hdf_iterate
+procedure, public :: visit => hdf_visit
 !! procedures without mapping
 
 !> below are procedure that need generic mapping (type or rank agnostic)
@@ -648,6 +650,58 @@ module logical function attr_exist(self, obj_name, attr_name)
 class(hdf5_file), intent(in) :: self
 character(*), intent(in) :: obj_name, attr_name
 end function
+
+module subroutine hdf_iterate(self, group_name, callback)
+ !! Opens the HDF5 file and the specified group, then iterates over
+ !! all members of the group. For each member the user‐provided
+ !! callback is invoked with:
+ !!
+ !!   group_name - name of the group
+ !!   object_name - name of the member object
+ !!   object_type - a short string indicating type ("group", "dataset",
+ !!                 "datatype", or "other")
+ class(hdf5_file), intent(in) :: self
+ character(len=*), intent(in) :: group_name
+  interface
+    subroutine user_callback_interface(group_name, object_name, object_type)
+      character(len=*), intent(in) :: group_name
+        !! The name of the group being traversed.
+      character(len=*), intent(in) :: object_name
+        !! The name of the object encountered.
+      character(len=*), intent(in) :: object_type
+        !!A short description such as "group", "dataset",
+        !!                            "datatype", or "other"
+    end subroutine
+  end interface
+
+ procedure(user_callback_interface) :: callback
+end subroutine
+
+module subroutine hdf_visit(self, group_name, callback)
+ !! Opens the HDF5 file and the specified group, then visits recursively
+ !! all members of the group. For each member the user‐provided
+ !! callback is invoked with:
+ !!
+ !!   group_name - name of the group
+ !!   object_name - name of the member object
+ !!   object_type - a short string indicating type ("group", "dataset",
+ !!                 "datatype", or "other")
+ class(hdf5_file), intent(in) :: self
+ character(len=*), intent(in) :: group_name
+  interface
+    subroutine user_callback_interface(group_name, object_name, object_type)
+      character(len=*), intent(in) :: group_name
+        !! The name of the group being traversed.
+      character(len=*), intent(in) :: object_name
+        !! The name of the object encountered.
+      character(len=*), intent(in) :: object_type
+        !!A short description such as "group", "dataset",
+        !!                            "datatype", or "other"
+    end subroutine
+  end interface
+
+ procedure(user_callback_interface) :: callback
+end subroutine
 
 end interface
 

--- a/src/iterate.f90
+++ b/src/iterate.f90
@@ -1,0 +1,112 @@
+submodule (h5fortran) iterate_smod
+  use hdf5
+  implicit none
+
+  interface
+    subroutine user_callback_interface(group_name, object_name, object_type)
+      character(len=*), intent(in) :: group_name
+        !! The name of the group being traversed.
+      character(len=*), intent(in) :: object_name
+        !! The name of the object encountered.
+      character(len=*), intent(in) :: object_type
+        !!A short description such as "group", "dataset",
+        !!                            "datatype", or "other"
+    end subroutine
+  end interface
+
+contains
+
+  module procedure hdf_iterate
+    use, intrinsic :: iso_c_binding, only: c_funptr, C_NULL_PTR, c_int
+    implicit none
+    integer(hid_t) :: group_id
+    integer(c_int) :: status
+    integer(hsize_t) :: idx
+    type(c_funptr) :: funptr
+    type(c_ptr) :: op_data_ptr
+    integer(c_int) :: return_value
+    procedure(user_callback_interface), pointer :: user_callback => null()
+
+    ! Fill the iteration data with the user’s group name and callback.
+    user_callback => callback
+
+    ! Open the group.
+    call H5Gopen_f(self%file_id, trim(group_name), group_id, status)
+    call estop(status, "hdf_iterate:H5Gopen_f", self%filename, "Error opening group: " // trim(group_name))
+
+    idx = 0
+    op_data_ptr = C_NULL_PTR
+    ! Get the C function pointer for our internal callback.
+    funptr = c_funloc(internal_iterate_callback)
+
+    ! Call H5Literate_f to iterate over the group.
+    call H5Literate_f(group_id, H5_INDEX_NAME_F, H5_ITER_NATIVE_F, idx, &
+                      funptr, op_data_ptr, return_value, status)
+    call estop(status, "hdf_iterate:H5Literate_f", self%filename, "Error during iteration of group: " // trim(group_name))
+
+    ! Close the group and file.
+    call H5Gclose_f(group_id, status)
+
+  contains
+
+    integer(c_int) function internal_iterate_callback(grp_id, name, info, op_data) bind(C)
+      !!  internal_iterate_callback:
+      !!
+      !!  This is the callback procedure that will be passed to H5Literate_f.
+      !!  It matches HDF5’s expected signature (using bind(C)) and is called
+      !!  for each object in the group.
+      !!
+      !!  It extracts the object name from the provided character array,
+      !!  calls H5Oget_info_by_name_f to determine the object type, and then
+      !!  calls the user's callback with the high-level parameters.
+      use ISO_C_BINDING, only: c_int, c_long, c_ptr, c_null_char
+      implicit none
+      integer(c_long), value        :: grp_id
+      character(kind=c_char, len=1) :: name(0:255)
+      type(h5l_info_t)              :: info
+      type(c_ptr)                   :: op_data
+
+      integer :: status, i, len
+      integer(hid_t) :: loc_id
+      type(H5O_info_t) :: infobuf
+      character(len=256) :: name_string
+      character(:), allocatable :: object_type
+
+      ! FIXME - This is a workaround for the Fortran unused variable warning/error.
+      if (info % type == info % type) continue
+      if (c_associated(op_data)) continue
+
+      ! Build a Fortran string from the character array.
+      do i = 0, 255
+        len = i
+        if (name(i) == c_null_char) exit
+        name_string(i+1:i+1) = name(i)(1:1)
+      end do
+
+      ! Retrieve object info using the object name.
+      loc_id = int(grp_id, kind=hid_t)
+      call H5Oget_info_by_name_f(loc_id, name_string(1:len), infobuf, status)
+      if (status /= 0) then
+        internal_iterate_callback = status
+        return
+      end if
+
+      if(infobuf % type == H5O_TYPE_GROUP_F)then
+        object_type = "group"
+      else if(infobuf % type == H5O_TYPE_DATASET_F)then
+        object_type = "dataset"
+      else if(infobuf % type == H5O_TYPE_NAMED_DATATYPE_F)then
+        object_type = "datatype"
+      else
+        object_type = "other"
+      endif
+
+      ! Call the user’s callback procedure.
+      call user_callback(group_name, name_string(1:len), object_type)
+
+      internal_iterate_callback = 0  ! Indicate success.
+    end function internal_iterate_callback
+
+  end procedure hdf_iterate
+
+end submodule

--- a/src/iterate.f90
+++ b/src/iterate.f90
@@ -1,23 +1,19 @@
 submodule (h5fortran) iterate_smod
   use hdf5
+  use, intrinsic :: iso_c_binding
   implicit none
 
   interface
     subroutine user_callback_interface(group_name, object_name, object_type)
       character(len=*), intent(in) :: group_name
-        !! The name of the group being traversed.
       character(len=*), intent(in) :: object_name
-        !! The name of the object encountered.
       character(len=*), intent(in) :: object_type
-        !!A short description such as "group", "dataset",
-        !!                            "datatype", or "other"
     end subroutine
   end interface
 
 contains
 
   module procedure hdf_iterate
-    use, intrinsic :: iso_c_binding, only: c_funptr, C_NULL_PTR, c_int
     implicit none
     integer(hid_t) :: group_id
     integer(c_int) :: status
@@ -27,84 +23,67 @@ contains
     integer(c_int) :: return_value
     procedure(user_callback_interface), pointer :: user_callback => null()
 
-    ! Fill the iteration data with the user’s group name and callback.
     user_callback => callback
 
-    ! Open the group.
     call H5Gopen_f(self%file_id, trim(group_name), group_id, status)
     call estop(status, "hdf_iterate:H5Gopen_f", self%filename, "Error opening group: " // trim(group_name))
 
-    idx = 0
+    idx = 0_hsize_t
     op_data_ptr = C_NULL_PTR
-    ! Get the C function pointer for our internal callback.
     funptr = c_funloc(internal_iterate_callback)
 
-    ! Call H5Literate_f to iterate over the group.
-    call H5Literate_f(group_id, H5_INDEX_NAME_F, H5_ITER_NATIVE_F, idx, &
-                      funptr, op_data_ptr, return_value, status)
+    call H5Literate_f(group_id, H5_INDEX_NAME_F, H5_ITER_NATIVE_F, idx, funptr, op_data_ptr, return_value, status)
     call estop(status, "hdf_iterate:H5Literate_f", self%filename, "Error during iteration of group: " // trim(group_name))
+    if (return_value < 0) then
+      call estop(1_c_int, "hdf_iterate:H5Literate", self%filename, "Error during iteration of group: " // trim(group_name))
+    end if
 
-    ! Close the group and file.
     call H5Gclose_f(group_id, status)
 
   contains
 
     integer(c_int) function internal_iterate_callback(grp_id, name, info, op_data) bind(C)
-      !!  internal_iterate_callback:
-      !!
-      !!  This is the callback procedure that will be passed to H5Literate_f.
-      !!  It matches HDF5’s expected signature (using bind(C)) and is called
-      !!  for each object in the group.
-      !!
-      !!  It extracts the object name from the provided character array,
-      !!  calls H5Oget_info_by_name_f to determine the object type, and then
-      !!  calls the user's callback with the high-level parameters.
-      use ISO_C_BINDING, only: c_int, c_long, c_ptr, c_null_char
       implicit none
-      integer(c_long), value        :: grp_id
-      character(kind=c_char, len=1) :: name(0:255)
-      type(h5l_info_t)              :: info
-      type(c_ptr)                   :: op_data
+      integer(c_intptr_t), value :: grp_id
+      character(kind=c_char), intent(in) :: name(*)
+      type(h5l_info_t), intent(in) :: info
+      type(c_ptr), value :: op_data
 
-      integer :: status, i, len
+      integer :: i, ln, obj_status
       integer(hid_t) :: loc_id
-      type(H5O_info_t) :: infobuf
-      character(len=256) :: name_string
+      type(h5o_info_t) :: obj_info
+      character(len=256) :: name_str
       character(:), allocatable :: object_type
 
-      ! FIXME - This is a workaround for the Fortran unused variable warning/error.
-      if (info % type == info % type) continue
+      if (info % corder == info % corder) continue
       if (c_associated(op_data)) continue
 
-      ! Build a Fortran string from the character array.
-      do i = 0, 255
-        len = i
+      ln = 0
+      do i = 1, 256
         if (name(i) == c_null_char) exit
-        name_string(i+1:i+1) = name(i)(1:1)
+        name_str(i:i) = name(i)
+        ln = i
       end do
 
-      ! Retrieve object info using the object name.
-      loc_id = int(grp_id, kind=hid_t)
-      call H5Oget_info_by_name_f(loc_id, name_string(1:len), infobuf, status)
-      if (status /= 0) then
-        internal_iterate_callback = status
-        return
-      end if
-
-      if(infobuf % type == H5O_TYPE_GROUP_F)then
-        object_type = "group"
-      else if(infobuf % type == H5O_TYPE_DATASET_F)then
-        object_type = "dataset"
-      else if(infobuf % type == H5O_TYPE_NAMED_DATATYPE_F)then
-        object_type = "datatype"
+      loc_id = int(grp_id, hid_t)
+      call H5Oget_info_by_name_f(loc_id, name_str(1:ln), obj_info, obj_status)
+      if (obj_status == 0) then
+        if (obj_info % type == H5O_TYPE_GROUP_F) then
+          object_type = "group"
+        else if (obj_info % type == H5O_TYPE_DATASET_F) then
+          object_type = "dataset"
+        else if (obj_info % type == H5O_TYPE_NAMED_DATATYPE_F) then
+          object_type = "datatype"
+        else
+          object_type = "other"
+        end if
       else
         object_type = "other"
-      endif
+      end if
 
-      ! Call the user’s callback procedure.
-      call user_callback(group_name, name_string(1:len), object_type)
+      call user_callback(group_name, name_str(1:ln), object_type)
 
-      internal_iterate_callback = 0  ! Indicate success.
+      internal_iterate_callback = 0
     end function internal_iterate_callback
 
   end procedure hdf_iterate

--- a/src/utils.f90
+++ b/src/utils.f90
@@ -366,8 +366,9 @@ elseif(any(c_mem_dims /= mem_dims)) then
   write(stderr,*) "ERROR:h5fortran:get_slice: memory size /= dataset size: check variable slice (index). " // &
     " Dset_dims:", ddims, "C Mem_dims:", c_mem_dims, "mem_dims:", mem_dims, "rank(mem_dims):", rank(mem_dims)
   error stop "ERROR:h5fortran:get_slice " // dset_name
-elseif(any(iend-istart+1 > ddims)) then
-  write(stderr,*) "ERROR:h5fortran:get_slice: iend: ", iend, ' > dset_dims: ', ddims
+elseif(any(iend-istart > ddims)) then
+  write(stderr,*) "ERROR:h5fortran:get_slice: slice bigger than dataset: check variable slice (index). " // &
+    " Dset_dims:", ddims, "C Mem_dims:", c_mem_dims, "mem_dims:", mem_dims, "rank(mem_dims):", rank(mem_dims)
   error stop "ERROR:h5fortran:get_slice " // dset_name
 endif
 

--- a/src/visit.f90
+++ b/src/visit.f90
@@ -1,0 +1,112 @@
+submodule (h5fortran) visit_smod
+  use hdf5
+  implicit none
+
+  interface
+    subroutine user_callback_interface(group_name, object_name, object_type)
+      character(len=*), intent(in) :: group_name
+        !! The name of the group being traversed.
+      character(len=*), intent(in) :: object_name
+        !! The name of the object encountered.
+      character(len=*), intent(in) :: object_type
+        !!A short description such as "group", "dataset",
+        !!                            "datatype", or "other"
+    end subroutine
+  end interface
+
+contains
+
+  module procedure hdf_visit
+    use, intrinsic :: iso_c_binding, only: c_funptr, C_NULL_PTR, c_int
+    implicit none
+    integer(hid_t) :: group_id
+    integer(c_int) :: status
+    integer(hsize_t) :: idx
+    type(c_funptr) :: funptr
+    type(c_ptr) :: op_data_ptr
+    integer(c_int) :: return_value
+    procedure(user_callback_interface), pointer :: user_callback => null()
+
+    ! Fill the iteration data with the user’s group name and callback.
+    user_callback => callback
+
+    ! Open the group.
+    call H5Gopen_f(self%file_id, trim(group_name), group_id, status)
+    call estop(status, "hdf_visit:H5Gopen_f", self%filename, "Error opening group: " // trim(group_name))
+
+    idx = 0
+    op_data_ptr = C_NULL_PTR
+    ! Get the C function pointer for our internal callback.
+    funptr = c_funloc(internal_visit_callback)
+
+    ! Call H5Lvisit_f to visit over the group.
+    call H5Ovisit_f(group_id, H5_INDEX_NAME_F, H5_ITER_NATIVE_F, &
+                      funptr, op_data_ptr, return_value, status)
+    call estop(status, "hdf_visit:H5Lvisit_f", self%filename, "Error during iteration of group: " // trim(group_name))
+
+    ! Close the group and file.
+    call H5Gclose_f(group_id, status)
+
+  contains
+
+    integer(c_int) function internal_visit_callback(grp_id, name, info, op_data) bind(C)
+      !!  internal_visit_callback:
+      !!
+      !!  This is the callback procedure that will be passed to H5Lvisit_f.
+      !!  It matches HDF5’s expected signature (using bind(C)) and is called
+      !!  for each object in the group.
+      !!
+      !!  It extracts the object name from the provided character array,
+      !!  calls H5Oget_info_by_name_f to determine the object type, and then
+      !!  calls the user's callback with the high-level parameters.
+      use ISO_C_BINDING, only: c_int, c_long, c_ptr, c_null_char
+      implicit none
+      integer(c_long), value        :: grp_id
+      character(kind=c_char, len=1) :: name(0:255)
+      type(h5l_info_t)              :: info
+      type(c_ptr)                   :: op_data
+
+      integer :: status, i, len
+      integer(hid_t) :: loc_id
+      type(H5O_info_t) :: infobuf
+      character(len=256) :: name_string
+      character(:), allocatable :: object_type
+
+      ! FIXME - This is a workaround for the Fortran unused variable warning/error.
+      if (info % type == info % type) continue
+      if (c_associated(op_data)) continue
+
+      ! Build a Fortran string from the character array.
+      do i = 0, 255
+        len = i
+        if (name(i) == c_null_char) exit
+        name_string(i+1:i+1) = name(i)(1:1)
+      end do
+
+      ! Retrieve object info using the object name.
+      loc_id = int(grp_id, kind=hid_t)
+      call H5Oget_info_by_name_f(loc_id, name_string(1:len), infobuf, status)
+      if (status /= 0) then
+        internal_visit_callback = status
+        return
+      end if
+
+      if(infobuf % type == H5O_TYPE_GROUP_F)then
+        object_type = "group"
+      else if(infobuf % type == H5O_TYPE_DATASET_F)then
+        object_type = "dataset"
+      else if(infobuf % type == H5O_TYPE_NAMED_DATATYPE_F)then
+        object_type = "datatype"
+      else
+        object_type = "other"
+      endif
+
+      ! Call the user’s callback procedure.
+      call user_callback(group_name, name_string(1:len), object_type)
+
+      internal_visit_callback = 0  ! Indicate success.
+    end function internal_visit_callback
+
+  end procedure hdf_visit
+
+end submodule

--- a/src/visit.f90
+++ b/src/visit.f90
@@ -1,110 +1,79 @@
 submodule (h5fortran) visit_smod
   use hdf5
+  use, intrinsic :: iso_c_binding
   implicit none
 
   interface
     subroutine user_callback_interface(group_name, object_name, object_type)
       character(len=*), intent(in) :: group_name
-        !! The name of the group being traversed.
       character(len=*), intent(in) :: object_name
-        !! The name of the object encountered.
       character(len=*), intent(in) :: object_type
-        !!A short description such as "group", "dataset",
-        !!                            "datatype", or "other"
     end subroutine
   end interface
 
 contains
 
   module procedure hdf_visit
-    use, intrinsic :: iso_c_binding, only: c_funptr, C_NULL_PTR, c_int
     implicit none
     integer(hid_t) :: group_id
     integer(c_int) :: status
-    integer(hsize_t) :: idx
     type(c_funptr) :: funptr
     type(c_ptr) :: op_data_ptr
     integer(c_int) :: return_value
     procedure(user_callback_interface), pointer :: user_callback => null()
 
-    ! Fill the iteration data with the user’s group name and callback.
     user_callback => callback
 
-    ! Open the group.
     call H5Gopen_f(self%file_id, trim(group_name), group_id, status)
     call estop(status, "hdf_visit:H5Gopen_f", self%filename, "Error opening group: " // trim(group_name))
 
-    idx = 0
     op_data_ptr = C_NULL_PTR
-    ! Get the C function pointer for our internal callback.
     funptr = c_funloc(internal_visit_callback)
 
-    ! Call H5Lvisit_f to visit over the group.
-    call H5Ovisit_f(group_id, H5_INDEX_NAME_F, H5_ITER_NATIVE_F, &
-                      funptr, op_data_ptr, return_value, status)
-    call estop(status, "hdf_visit:H5Lvisit_f", self%filename, "Error during iteration of group: " // trim(group_name))
+    call H5Ovisit_f(group_id, H5_INDEX_NAME_F, H5_ITER_NATIVE_F, funptr, op_data_ptr, return_value, status)
+    call estop(status, "hdf_visit:H5Ovisit_f", self%filename, "Error during visit of group: " // trim(group_name))
+    if (return_value < 0) then
+      call estop(1_c_int, "hdf_visit:H5Ovisit", self%filename, "Error during visit of group: " // trim(group_name))
+    end if
 
-    ! Close the group and file.
     call H5Gclose_f(group_id, status)
 
   contains
 
     integer(c_int) function internal_visit_callback(grp_id, name, info, op_data) bind(C)
-      !!  internal_visit_callback:
-      !!
-      !!  This is the callback procedure that will be passed to H5Lvisit_f.
-      !!  It matches HDF5’s expected signature (using bind(C)) and is called
-      !!  for each object in the group.
-      !!
-      !!  It extracts the object name from the provided character array,
-      !!  calls H5Oget_info_by_name_f to determine the object type, and then
-      !!  calls the user's callback with the high-level parameters.
-      use ISO_C_BINDING, only: c_int, c_long, c_ptr, c_null_char
       implicit none
-      integer(c_long), value        :: grp_id
-      character(kind=c_char, len=1) :: name(0:255)
-      type(h5l_info_t)              :: info
-      type(c_ptr)                   :: op_data
+      integer(c_intptr_t), value :: grp_id
+      character(kind=c_char), intent(in) :: name(*)
+      type(h5o_info_t), intent(in) :: info
+      type(c_ptr), value :: op_data
 
-      integer :: status, i, len
-      integer(hid_t) :: loc_id
-      type(H5O_info_t) :: infobuf
-      character(len=256) :: name_string
+      character(len=256) :: name_str
       character(:), allocatable :: object_type
+      integer :: i, ln
 
-      ! FIXME - This is a workaround for the Fortran unused variable warning/error.
-      if (info % type == info % type) continue
+      if (grp_id /= 0_c_intptr_t) continue
       if (c_associated(op_data)) continue
 
-      ! Build a Fortran string from the character array.
-      do i = 0, 255
-        len = i
+      ln = 0
+      do i = 1, 256
         if (name(i) == c_null_char) exit
-        name_string(i+1:i+1) = name(i)(1:1)
+        name_str(i:i) = name(i)
+        ln = i
       end do
 
-      ! Retrieve object info using the object name.
-      loc_id = int(grp_id, kind=hid_t)
-      call H5Oget_info_by_name_f(loc_id, name_string(1:len), infobuf, status)
-      if (status /= 0) then
-        internal_visit_callback = status
-        return
-      end if
-
-      if(infobuf % type == H5O_TYPE_GROUP_F)then
+      if (info % type == H5O_TYPE_GROUP_F) then
         object_type = "group"
-      else if(infobuf % type == H5O_TYPE_DATASET_F)then
+      else if (info % type == H5O_TYPE_DATASET_F) then
         object_type = "dataset"
-      else if(infobuf % type == H5O_TYPE_NAMED_DATATYPE_F)then
+      else if (info % type == H5O_TYPE_NAMED_DATATYPE_F) then
         object_type = "datatype"
       else
         object_type = "other"
-      endif
+      end if
 
-      ! Call the user’s callback procedure.
-      call user_callback(group_name, name_string(1:len), object_type)
+      call user_callback(group_name, name_str(1:ln), object_type)
 
-      internal_visit_callback = 0  ! Indicate success.
+      internal_visit_callback = 0
     end function internal_visit_callback
 
   end procedure hdf_visit

--- a/src/write.f90
+++ b/src/write.f90
@@ -91,7 +91,9 @@ if(self%exist(dname)) then
   call estop(ier, "create:H5Dget_space", self%filename, dname)
 
 
-  if (present(istart) .and. present(iend)) then
+  if (present(istart)) then
+    if(any(istart < 1)) error stop 'ERROR:h5fortran:create: istart must be >= 1'
+    if(any(iend < istart)) error stop 'ERROR:h5fortran:create: iend must be >= istart'
     call H5Sget_simple_extent_ndims_f(filespace_id, drank, ier)
     call estop(ier, "create:H5Sget_simple_extent_ndims", self%filename, dname)
 
@@ -116,17 +118,14 @@ if(self%exist(dname)) then
     allocate(ddims(drank), maxdims(drank))
 
     call H5Sget_simple_extent_dims_f(filespace_id, ddims, maxdims, ier)
-    if (ier /= drank) error stop 'ERROR:h5fortran:create: H5Sget_simple_extent_dims: ' // dname // ' in ' // self%filename
+    if (ier /= drank) &
+      error stop 'ERROR:h5fortran:create: H5Sget_simple_extent_dims: ' // dname // ' in ' // self%filename
 
-    do i = 1, drank
-      if (iend(i) - istart(i) > ddims(i)) emsg = 'ERROR:h5fortran:create: iend - istart > dset_dims'
-    enddo
-    if (allocated(emsg)) then
-      write(stderr,*) emsg // " dataset: " // dname // " file: " // self%filename // " istart: ", &
-        istart, " iend: ", iend, " ddims: ", ddims, " maxdims: ", maxdims
+    if(any(iend - istart > ddims)) then
+      write(stderr,*) 'ERROR:h5fortran:create: iend - istart > dset_dims dataset: ', dname, &
+        ' file: ', self%filename, ' istart: ', istart, ' iend: ', iend, ' ddims: ', ddims
       error stop
     endif
-
   else
     if (size(mem_dims) == 0) then
       !! scalar

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -74,7 +74,7 @@ endfunction(setup_test)
 set(test_names array attributes
 cast deflate_write deflate_read deflate_props destructor exist
 groups layout lt scalar shape string version write
-fail_read_size_mismatch fail_read_rank_mismatch fail_nonexist_variable)
+fail_read_size_mismatch fail_read_rank_mismatch fail_nonexist_variable iterate visit)
 if(HAVE_IEEE_ARITH)
   list(APPEND test_names fill)
 endif()
@@ -112,9 +112,6 @@ endif()
 # --- attributes
 
 if(h5py_ok)
-
-set_property(TEST string_read PROPERTY FIXTURES_REQUIRED h5str)
-set_property(TEST string_read PROPERTY REQUIRED_FILES ${string_file})
 
 add_test(NAME PythonAttributes
 COMMAND Python::Interpreter ${CMAKE_CURRENT_SOURCE_DIR}/generate_attributes.py ${attr_file}

--- a/test/test_iterate.f90
+++ b/test/test_iterate.f90
@@ -1,0 +1,48 @@
+program test_iterate
+  use, intrinsic :: iso_fortran_env, only: real64
+  use h5fortran
+  use hdf5
+  implicit none
+
+  type(hdf5_file) :: h
+  character(*), parameter :: filename='test_iterate.h5'
+  integer :: i
+
+  i = 0
+
+  ! Create a sample HDF5 file
+  call h%open(filename, "w")
+
+  call h%create_group("/group1")
+  call h%create_group("/group1/group2")
+  call h%write("/dataset1", 1.0_real64)
+  call h%write("/group1/dataset2", 2.0_real64)
+
+  call h%close()
+
+  ! Reopen the file for testing
+  call h%open(filename, "r")
+
+  ! iterate the root group
+  print*, "test_iterate: iterating root group"
+  call h%iterate("/", my_callback)
+
+  print*, "test_iterate: iterating /group1"
+  ! iterate a subgroup
+  call h%iterate("/group1", my_callback)
+
+  call h%close()
+
+  print*, "test_iterate: found ", i, " objects"
+  if (i /= 4) error stop "test_iterate: expected 4 objects"
+
+contains
+
+  ! Define a callback subroutine
+  subroutine my_callback(group_name, object_name, object_type)
+    character(len=*), intent(in) :: group_name, object_name, object_type
+    print *, "test_iterate: at group ", trim(group_name), ' we found ', trim(object_name), ' which is a ', trim(object_type)
+    i = i + 1
+  end subroutine my_callback
+
+end program test_iterate

--- a/test/test_visit.f90
+++ b/test/test_visit.f90
@@ -1,0 +1,48 @@
+program test_visit
+  use, intrinsic :: iso_fortran_env, only: real64
+  use h5fortran
+  use hdf5
+  implicit none
+
+  type(hdf5_file) :: h
+  character(*), parameter :: filename='test_visit.h5'
+  integer :: i
+
+  i = 0
+
+  ! Create a sample HDF5 file
+  call h%open(filename, "w")
+
+  call h%create_group("/group1")
+  call h%create_group("/group1/group2")
+  call h%write("/dataset1", 1.0_real64)
+  call h%write("/group1/dataset2", 2.0_real64)
+
+  call h%close()
+
+  ! Reopen the file for testing
+  call h%open(filename, "r")
+
+  ! visit the root group
+  print*, "test_visit: visiting root group"
+  call h%visit("/", my_callback)
+
+  print*, "test_visit: visiting /group1"
+  ! visit a subgroup
+  call h%visit("/group1", my_callback)
+
+  call h%close()
+
+  print*, "test_visit: found ", i, " objects"
+  if (i /= 8) error stop "test_visit: expected 8 objects"
+
+contains
+
+  ! Define a callback subroutine
+  subroutine my_callback(group_name, object_name, object_type)
+    character(len=*), intent(in) :: group_name, object_name, object_type
+    print *, "test_visit: at group ", trim(group_name), ' we found ', trim(object_name), ' that is a ', trim(object_type)
+    i = i + 1
+  end subroutine my_callback
+
+end program test_visit


### PR DESCRIPTION
## Summary
Add `iterate` and `visit` procedures for traversing HDF5 groups in h5fortran, plus bug fixes including SIGSEGV with Intel ifx compiler.
## New Features
- **`iterate`**: Iterate over all objects in an HDF5 group using a user-defined callback
- **`visit`**: Recursively visit all objects starting from an HDF5 group using a user-defined callback
Both accept a callback receiving: group_name, object_name, object_type ("group", "dataset", "datatype", "other")
## Bug Fixes
- **Intel ifx SIGSEGV**: Fixed in commit `6377e27` (cross-version HDF5 compatibility)
- **Error message improvements**: Fixed slice bounds checking in `src/utils.f90:369` and `src/write.f90:119`
- **fpm.toml**: Added test entries for iterate and visit
## Other Changes
- Build: Updated `src/CMakeLists.txt` and `test/CMakeLists.txt` for new source files
- Docs: Added API documentation in `API.md`
- Tests: Added `test/test_iterate.f90` and `test/test_visit.f90`
- Gitignore: Added build artifacts
## Test Results
| Environment | Result |
|-------------|--------|
| GCC 14 | 26/26 pass |
| Intel ifx | pass (no segfault) |
| HDF5 1.10 CI | pass |
| HDF5 1.12+ CI | pass |